### PR TITLE
Fix typo in tablespace creation script

### DIFF
--- a/create_tpe_ftex.sql
+++ b/create_tpe_ftex.sql
@@ -2,8 +2,8 @@
 -- FTEX
 --
 CONNECT sys/oracle@//localhost/FTEX as sysdba
-CREATE TABLESPACE tpe_data DATAFILE '/u02/oradata/FTEX/tep_data01.dbf' SIZE 1G;
-CREATE TABLESPACE tpe_index DATAFILE '/u02/oradata/FTEX/tep_index01.dbf' SIZE 1G;
+CREATE TABLESPACE tpe_data DATAFILE '/u02/oradata/FTEX/tpe_data01.dbf' SIZE 1G;
+CREATE TABLESPACE tpe_index DATAFILE '/u02/oradata/FTEX/tpe_index01.dbf' SIZE 1G;
 
 CREATE USER tpe IDENTIFIED BY oracle
 DEFAULT TABLESPACE tpe_data;


### PR DESCRIPTION
## Summary
- fix typo in datafile names in `create_tpe_ftex.sql`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68638ec75f788327992d33bed8f72292