### PR TITLE
Fix typos and improve SQL scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,16 @@
+name: Shellcheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: |
+          shellcheck $(git ls-files '*.sh')

--- a/capture_cc.sql
+++ b/capture_cc.sql
@@ -1,5 +1,5 @@
 -- -----------------------------------------------------------------------------------
--- File Name    : https://MikeDietrichDE.com/wp-content/scripts/12c/check_patches.sql
+-- File Name    : capture_cc.sql (from Mike Dietrich's scripts)
 -- Author       : Mike Dietrich
 -- Description  : Capture SQL Statements from Cursor Cache into a SQL Tuning Set
 -- Requirements : Access to the DBA role.

--- a/checksnap.sql
+++ b/checksnap.sql
@@ -16,14 +16,12 @@ BEGIN
 SELECT min(snap_id)
 INTO begin_id
 FROM dba_hist_snapshot
-WHERE to_char(begin_interval_time,'DD-MON-YY') = to_char(sysdate,'DD-MON-YY')
-ORDER BY snap_id;
+WHERE to_char(begin_interval_time,'DD-MON-YY') = to_char(sysdate,'DD-MON-YY');
 
 SELECT max(snap_id)
 INTO end_id
 FROM dba_hist_snapshot
-WHERE to_char(begin_interval_time,'DD-MON-YY') = to_char(sysdate,'DD-MON-YY') 
-ORDER BY snap_id;
+WHERE to_char(begin_interval_time,'DD-MON-YY') = to_char(sysdate,'DD-MON-YY');
 
 DBMS_OUTPUT.PUT_LINE('AWR Snapshots created today: ' || begin_id || ' ==> ' || end_id );
 

--- a/snapcheck.sql
+++ b/snapcheck.sql
@@ -7,7 +7,7 @@ SET FEEDBACK OFF
 
 BEGIN
 
-DBMS_OUTPUT.PUT_LINE('These AWR snapshots where created today:');
+DBMS_OUTPUT.PUT_LINE('These AWR snapshots were created today:');
 select snap_id from dba_hist_snapshot where to_char(begin_interval_time,'DD-MON-YY') = to_char(sysdate,'DD-MON-YY') order by snap_id;
 END;
 /


### PR DESCRIPTION
## Summary
- correct message in `snapcheck.sql`
- remove invalid `ORDER BY` statements in `checksnap.sql`
- fix file name in `capture_cc.sql` header
- add a GitHub Actions workflow that runs shellcheck on `.sh` files

## Testing
- `shellcheck $(git ls-files '*.sh')`

------
https://chatgpt.com/codex/tasks/task_b_68638ec7b9b08327a34a8f0c2195267b